### PR TITLE
cicd: Fix lint and release pipelines

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,11 @@
 
 version: 2
 updates:
- - package-ecosystem: "devcontainers"
-   directory: "/"
-   schedule:
-     interval: weekly
+   - package-ecosystem: github-actions
+     directory: "/"
+     schedule:
+       interval: weekly
+   - package-ecosystem: "devcontainers"
+     directory: "/"
+     schedule:
+       interval: weekly

--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -30,9 +30,9 @@ jobs:
           go-version: '1.22.4'
           check-latest: true
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: v1.59
   test:
     name: Run tests
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,7 @@ defaults:
 
 jobs:
   release:
+    needs: [conventional-commits, lint, test]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
* Fix dependency of release on Lint and test (needs for requiring successful completion)
* Adjust golang-lint ci and add .golangci.yaml file